### PR TITLE
**Feat: Complete `review-and-submit.html` page**

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ src/staticfiles/
 # Django static files
 staticfiles/
 
+staticfiles_build/
+
 
 ### Django.Python Stack ###
 # Byte-compiled / optimized / DLL files

--- a/src/account/forms/forms.py
+++ b/src/account/forms/forms.py
@@ -21,6 +21,8 @@ class BasicFormDescription(forms.Form):
                            })
                            )
 
+    is_featured_item = forms.ChoiceField(label="Featured item", choices=CATEGORY_CHOICES, initial=CATEGORY_CHOICES[0])
+
     category = forms.ChoiceField(label="Select a product category", 
                                  choices=get_product_category_choices(),
                                  widget=forms.Select(attrs={
@@ -28,7 +30,6 @@ class BasicFormDescription(forms.Form):
                                      "class": "select-category",
                                  }))
 
-    is_featured_item = forms.ChoiceField(label="Featured item", choices=CATEGORY_CHOICES, initial=CATEGORY_CHOICES[0])
     new_category = forms.CharField(max_length=100, required=False,
                                    widget=forms.TextInput(attrs={
                                        "id": "add-category",
@@ -97,30 +98,32 @@ class PricingAndInventoryForm(forms.Form):
                                       widget=forms.NumberInput(attrs={"min": "1",
                                                                       "max": "1000000",
                                                                       "step": "0.01",
-                                                                      "id": "add-discount"
+                                                                      "id": "add-discount",
+                                                                       "type": "number",
                                                                       }))
 
     quantity_stock = forms.FloatField(label="Quantity in stock",
-                                      widget=forms.NumberInput(attrs={"min": "1",
+                                      widget=forms.NumberInput(attrs={"min": "0",
                                                                       "max": "1000000",
                                                                       "step": "1",
                                                                       "id": "quantity-stock",
-                                                                      "required": True
+                                                                      "type": "number",
                                                                       }))
 
     minimum_order = forms.FloatField(label="Minimum order quantity",
-                                     widget=forms.NumberInput(attrs={"min": "1",
+                                     widget=forms.NumberInput(attrs={"min": "0",
                                                                      "max": "1000000",
                                                                      "step": "1",
                                                                      "id": "minimum-order-quantity",
-                                                                     "required": True
+                                                                      "type": "number",
+                                                                    
                                                                      }))
     maximum_order = forms.FloatField(label="Maximum order quantity",
-                                     widget=forms.NumberInput(attrs={"min": "1",
+                                     widget=forms.NumberInput(attrs={"min": "0",
                                                                      "max": "1000000",
                                                                      "step": "1",
                                                                      "id": "maximum-order-quantity",
-                                                                     "required": True
+                                                                    
                                                                      }))
 
 

--- a/src/account/utils/product_category_utils.py
+++ b/src/account/utils/product_category_utils.py
@@ -86,23 +86,24 @@ def get_product_category_choices():
 def get_product_color_choices():
     
     colors = [
-           {"id": "colorRed",    "name": "color",  "data_color": "red",    "value": "red"},
-           {"id": "colorGreen",  "name": "color",  "data_color": "green",  "value": "green"},
-           {"id": "colorBlue",   "name": "color",  "data_color": "blue",   "value": "blue"},
-           {"id": "colorYellow", "name": "color",  "data_color": "yellow", "value": "yellow"},
-           {"id": "colorBlack",  "name": "color",  "data_color": "black",  "value": "black"},
-           {"id": "colorWhite",  "name": "color",  "data_color": "white",  "value": "white"},
-           {"id": "colorPurple", "name": "color",  "data_color": "purple", "value": "purple"},
-           {"id": "colorOrange", "name": "color",  "data_color": "orange", "value": "orange"},
-           {"id": "colorPink",   "name": "color",  "data_color": "pink",   "value": "pink"},
-           {"id": "colorBrown",  "name": "color",  "data_color": "brown",  "value": "brown"},
-           {"id": "colorGray",   "name": "color",  "data_color": "gray",   "value": "gray"},
-           {"id": "colorCyan",   "name": "color",  "data_color": "cyan",   "value": "cyan"},
-           {"id": "colorMagenta", "name": "color", "data_color": "magenta", "value": "magenta"},
-           {"id": "colorLime",   "name": "color",  "data_color": "lime",   "value": "lime"},
-           {"id": "colorTeal",   "name": "color",  "data_color": "teal",   "value": "teal"},
-           {"id": "colorIndigo", "name": "color",  "data_color": "indigo", "value": "indigo"}
-       ]
+        {"id": "colorRed",    "name": "color",  "value": "Red"},
+        {"id": "colorGreen",  "name": "color",  "value": "Green"},
+        {"id": "colorBlue",   "name": "color",  "value": "Blue"},
+        {"id": "colorYellow", "name": "color",  "value": "Yellow"},
+        {"id": "colorBlack",  "name": "color",  "value": "Black"},
+        {"id": "colorWhite",  "name": "color",  "value": "White"},
+        {"id": "colorPurple", "name": "color",  "value": "Purple"},
+        {"id": "colorOrange", "name": "color",  "value": "Orange"},
+        {"id": "colorPink",   "name": "color",  "value": "Pink"},
+        {"id": "colorBrown",  "name": "color",  "value": "Brown"},
+        {"id": "colorGray",   "name": "color",  "value": "Gray"},
+        {"id": "colorCyan",   "name": "color",  "value": "Cyan"},
+        {"id": "colorMagenta", "name": "color", "value": "Magenta"},
+        {"id": "colorLime",   "name": "color",  "value": "Lime"},
+        {"id": "colorTeal",   "name": "color",  "value": "Teal"},
+        {"id": "colorIndigo", "name": "color",  "value": "Indigo"}
+    ]
+
     
     return colors
 
@@ -110,9 +111,9 @@ def get_product_color_choices():
 
 def get_product_size_choices():
     sizes = [
-        {"id" :"small",  "name": "size", "value" : "small",  "data_size": "small",  "class": "item-small"},
-        {"id" :"medium", "name": "size", "value" : "medium", "data_size": "medium", "class": "item-medium"},
-        {"id" :"large",  "name": "size", "value" : "large",  "data_size": "large",  "class": "item-large"}
+        {"id" :"small",  "name": "size", "value" : "Small",  "data_size": "small",  "class": "item-small"},
+        {"id" :"medium", "name": "size", "value" : "Medium", "data_size": "medium", "class": "item-medium"},
+        {"id" :"large",  "name": "size", "value" : "Large",  "data_size": "large",  "class": "item-large"}
     ]
     return sizes
 
@@ -134,12 +135,7 @@ def get_shipping_options():
             "label": "Standard Shipping (3-5 business days) - £3.99",
             "input": {
                 "name": "shipping",
-                "value": "standard",
-                "data": {
-                    "shipping_type": "standard",
-                    "cost": "3.99",
-                    "delivery_time": "3-5 business days"
-                },
+                "value": "Standard",
                 "aria": {
                     "describedby": "standard-desc"
                 },
@@ -154,12 +150,7 @@ def get_shipping_options():
             "label": "Express Shipping (1-2 business days) - £5.99",
             "input": {
                 "name": "shipping",
-                "value": "express",
-                "data": {
-                    "shipping_type": "express",
-                    "cost": "5.99",
-                    "delivery_time": "1-2 business days"
-                },
+                "value": "Express",
                 "aria": {
                     "describedby": "express-desc"
                 },
@@ -174,12 +165,7 @@ def get_shipping_options():
             "label": "Next-Day Delivery - £9.99",
             "input": {
                 "name": "shipping",
-                "value": "next-day",
-                "data": {
-                    "shipping_type": "next-day",
-                    "cost": "9.99",
-                    "delivery_time": "Next-Day Delivery"
-                },
+                "value": "Next-Day-Delivery",
                 "aria": {
                     "describedby": "next-day-desc"
                 },
@@ -194,12 +180,7 @@ def get_shipping_options():
             "label": "Same-Day Delivery (order by 2 PM) - £14.99",
             "input": {
                 "name": "shipping",
-                "value": "same-day",
-                "data": {
-                    "shipping_type": "same-day",
-                    "cost": "14.99",
-                    "delivery_time": "Same-Day Delivery (order by 2 PM)"
-                },
+                "value": "Same-Day",
                 "aria": {
                     "describedby": "same-day-desc"
                 },
@@ -214,12 +195,7 @@ def get_shipping_options():
             "label": "Click and Collect (1-2 days) - Free",
             "input": {
                 "name": "shipping",
-                "value": "click-collect",
-                "data": {
-                    "shipping_type": "click-collect",
-                    "cost": "0.00",
-                    "delivery_time": "1-2 days"
-                },
+                "value": "Click-Collect",
                 "aria": {
                     "describedby": "click-collect-desc"
                 },
@@ -234,12 +210,7 @@ def get_shipping_options():
             "label": "Weekend Delivery - £7.99",
             "input": {
                 "name": "shipping",
-                "value": "weekend",
-                "data": {
-                    "shipping_type": "weekend",
-                    "cost": "7.99",
-                    "delivery_time": "Weekend Delivery"
-                },
+                "value": "Weekend",
                 "aria": {
                     "describedby": "weekend-desc"
                 },
@@ -254,12 +225,7 @@ def get_shipping_options():
             "label": "Free Shipping (orders over £50) - Free",
             "input": {
                 "name": "shipping",
-                "value": "free",
-                "data": {
-                    "shipping_type": "free",
-                    "cost": "0.00",
-                    "delivery_time": "Free Shipping (orders over £50)"
-                },
+                "value": "Free",
                 "aria": {
                     "describedby": "free-desc"
                 },

--- a/src/account/utils/utils.py
+++ b/src/account/utils/utils.py
@@ -1,3 +1,5 @@
+import base64
+
 from os.path import splitext, join
 import tempfile
 
@@ -28,6 +30,16 @@ def save_file_temporarily(uploaded_file):
     
     return temp_file_path
 
+
+def get_saved_temp_file(temp_file_path):
+    with open(temp_file_path, 'rb') as file:
+        file_bytes = file.read()
+        return file_bytes
+
+
+def encode_image_bytes_to_base64(image_bytes):
+    return base64.b64encode(image_bytes).decode('utf-8')
+    
 
 def create_unique_file_name(original_name):
     

--- a/src/account/views.py
+++ b/src/account/views.py
@@ -95,7 +95,7 @@ def add_shipping_and_delivery(request):
                        session_key="shipping_and_delivery",
                        next_url_name="seo_and_meta_form",
                        template_name="account/product-management/add-new-product/shipping-and-delivery.html",
-                       checkbox_fields_to_store=("shipping")
+                       checkbox_fields_to_store=("shipping",)
                        )
 
 
@@ -119,28 +119,21 @@ def add_additonal_information(request):
 
 
 def view_review(request):
-    context = {
-        "section_id" : "review-section",
-        'is_review_section': True
-    }
+    context = { "section_id" : "review-section", 'is_review_section': True}
     
-    basic_form_session           = request.session.get("basic_form_description", {})
-    detailed_form_session        = request.session.get("detailed_form_description", {})
-    price_and_inventory_session  = request.session.get("pricing_and_inventory_form", {})
-    image_and_media_session      = request.session.get("temp_file_paths", {})
-    
-    detailed_form_data_colors, detailed_form_data_sizes  = request.session.get("color"), request.session.get("size")
-    
-    if (not detailed_form_data_colors or not detailed_form_data_sizes):
-        raise Exception("There must be at least one color or one size")
-    
-    detailed_form_session["colors"] = detailed_form_data_colors
-    detailed_form_session["sizes"]  = detailed_form_data_sizes
-    
-    images = get_base64_images_from_session(image_and_media_session)
+    image_and_media_session = request.session.get("temp_file_paths", {})
   
-    print(images)
-   
+    # add to the context
+    context["basic_form_data"]             = request.session.get("basic_form_description", {})
+    context["detailed_form_data"]          = request.session.get("detailed_form_description", {})
+    context["price_and_inventory_data"]    = request.session.get("pricing_and_inventory_form", {})
+    context["image_and_media_data"]        = get_base64_images_from_session(image_and_media_session)
+    context["shipping_and_delivery_data"]  = request.session.get("shipping_and_delivery", {})
+    context["seo_management_data"]         = request.session.get("seo_management", {})
+    context["additional_information_data"] = request.session.get("additional_information", {})
+    
+    print(context["additional_information_data"] )
+    
     return render(request, "account/product-management/add-new-product/review-and-submit.html", context=context)
  
  

--- a/src/account/views.py
+++ b/src/account/views.py
@@ -10,7 +10,9 @@ from .forms.forms     import (BasicFormDescription,
                               SeoAndMetaForm,
                               AdditionalInformationForm,
                               )
-from .utils.utils     import create_unique_file_name, save_file_temporarily
+
+
+from .views_helpers import get_base64_images_from_session
 
 
 # Create your views here.
@@ -26,6 +28,7 @@ def product_management(request):
 
 
 def add_basic_description(request):
+    
     return handle_form(
         request=request,
         form_class=BasicFormDescription,
@@ -75,7 +78,7 @@ def add_images_and_media(request):
                 
                 for field in file_fields:
                     if field in request.FILES:
-                        temp_file_paths[field] = save_file_temporarily(request.FILES[field])
+                        temp_file_paths[field]  = save_file_temporarily(request.FILES[field])
                 request.session["temp_file_paths"] = temp_file_paths
                 
             return redirect(reverse("shipping_and_delivery_form"))
@@ -118,6 +121,24 @@ def view_review(request):
         "section_id" : "review-section",
         'is_review_section': True
     }
+    
+    basic_form_session           = request.session.get("basic_form_description", {})
+    detailed_form_session        = request.session.get("detailed_form_description", {})
+    price_and_inventory_session  = request.session.get("pricing_and_inventory_form", {})
+    image_and_media_session      = request.session.get("temp_file_paths", {})
+    
+    detailed_form_data_colors, detailed_form_data_sizes  = request.session.get("color"), request.session.get("size")
+    
+    if (not detailed_form_data_colors or not detailed_form_data_sizes):
+        raise Exception("There must be at least one color or one size")
+    
+    detailed_form_session["colors"] = detailed_form_data_colors
+    detailed_form_session["sizes"]  = detailed_form_data_sizes
+    
+    images = get_base64_images_from_session(image_and_media_session)
+  
+    print(images)
+   
     return render(request, "account/product-management/add-new-product/review-and-submit.html", context=context)
  
  

--- a/src/account/views.py
+++ b/src/account/views.py
@@ -1,6 +1,8 @@
 from django.shortcuts import render, redirect
 from django.urls      import reverse
 
+from account.utils.utils import save_file_temporarily
+
 from .views_helpers   import handle_form
 from .forms.forms     import (BasicFormDescription, 
                               DetailedFormDescription,

--- a/src/static/css/css.css
+++ b/src/static/css/css.css
@@ -3046,14 +3046,14 @@ legend {
 
 .review-img {
     height: 150px;
-    width: 220px;
+    width: 150px;
 }
 
 .img-preview  {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     grid-template-rows: auto;
-    column-gap: 2px;
+    column-gap: 6px;
     margin-bottom: var(--padding-lg);
 }
 

--- a/src/static/js/components/add-product.js
+++ b/src/static/js/components/add-product.js
@@ -1,7 +1,6 @@
 
 import { minimumCharactersToUse } from "./characterCounter.js";
-import {getItemFromLocalStorage, saveToLocalStorage, getAllCheckBoxElementsValue,
-        getCurrentPage, disableEmptySelectOptions as handleEmptySelectOptions
+import {getAllCheckBoxElementsValue, disableEmptySelectOptions as handleEmptySelectOptions
 } from "../utils/utils.js";
 
 import AlertUtils from "../utils/alerts.js";
@@ -139,62 +138,6 @@ selectDiscountCategoryElement?.addEventListener("change", () => toggleInputVisib
 
 
 
-
-/**
- * Updates form input fields with saved values when a form page loads.
- * 
- * This function determines the current page and retrieves the corresponding form element.
- * It then loads the saved values for that form from local storage and updates the form's input fields.
- * If the user had selected "new" or "yes" as the category in the dropdown menu, it resets the dropdown to the default state.
- * 
- * @returns {void}
- */
-function updateFormValue() {
-    const currentPage = getCurrentPage();
-
-    const formElements = {
-        "basic-product-information.html": basicForm,
-        "detailed-description-specs.html": detailedForm,
-        "pricing-inventory.html": pricingInventoryForm,
-        "images-and-media.html": imageAndMediaForm,
-        "shipping-and-delivery.html": shippingAndDeliveryForm,
-        "SEO-and-meta-information.html": seoAndMetaForm,
-        "additonal-information.html": additionInformationForm,
-    };
-
-    if (!currentPage || formElements[currentPage] === undefined) {
-        console.warn(`No form element found for current page: ${currentPage}`);
-        return;
-    }
-
-    const formDetails = formElements[currentPage];
-    const productValues = getItemFromLocalStorage(formDetails.id, true);
-    const productSelectCategory = basicForm?.querySelector("#select-category");
-    const discountSelectCategory = pricingInventoryForm?.querySelector("#select-discount");
-
-    // Iterate over the form elements and update their values using their saved data
-    for (let element of formDetails.elements) {
-
-        if (element.name) {
-            element.value = productValues[element.name] || '';   // Fallback to empty string if no value
-        };
-
-    }
-
-    // If the user had selected "new" or "yes" as the category for the dropdown menu, reset the dropdown to the default state
-    // This indicates that the user did not choose a predefined category but entered a custom one instead
-    if ( productSelectCategory && productSelectCategory.value === "new") {
-         productSelectCategory.value = "";
-    };
-
-    if (discountSelectCategory && discountSelectCategory.value === "yes") {
-       discountSelectCategory.value = "";
-   }
-}
-
-
-
-
 // Handles the form submission for basic-product-information.html
 function handleBasicInformationForm(e) {
     e.preventDefault();
@@ -241,20 +184,7 @@ function handleDetailedInformationForm(e) {
 
 
     if (detailedForm.reportValidity() && formComplete) {
-
-        const colors = getAllCheckBoxElementsValue(colorsCheckboxes, 'data-color');
-        const sizes = getAllCheckBoxElementsValue(sizeCheckBoxes, 'data-size');
-        const formEntries = getFormEntries(detailedForm);
-
-        formEntries.colorsOptions = colors;
-        formEntries.sizesOptions = sizes;
-
-        delete formEntries["color"];
-        delete formEntries["size"]
-
-
-        handleFormComplete(detailedForm, formEntries);
-
+        handleFormSubmission(detailedForm)
     }
 }
 
@@ -272,12 +202,8 @@ function handlePriceInventoryForm(e) {
 function handleImageAndMediaForm(e) {
 
     e.preventDefault();
+    handleFormSubmission(imageAndMediaForm)
   
-    if (imageAndMediaForm.reportValidity()) {
-       imageAndMediaForm.submit()
-    }
-  
-
 };
 
 
@@ -304,9 +230,7 @@ function handleShippingAndDeliveryForm(e) {
     };
 
     if (shippingAndDeliveryForm.reportValidity() && formComplete) {
-        const formEntries = getFormEntries(shippingAndDeliveryForm);
-        formEntries.deliveryOptions = getAllCheckBoxElementsValue(deliveryCheckboxes, 'data-delivery-time');
-        handleFormComplete(shippingAndDeliveryForm, formEntries);
+        handleFormSubmission(shippingAndDeliveryForm)
     }
 
 }
@@ -330,16 +254,11 @@ function handleAdditionalFormInfo(e) {
 
 function handleFormSubmission(form) {
     if (form.reportValidity()) {
-        handleFormComplete(form, getFormEntries(form));
+        form.submit()
     }
 }
 
 
-function handleFormComplete(form, formEntries) {
-    saveToLocalStorage(form.id, formEntries, true);
-    form.submit()
-
-}
 
 
 

--- a/src/static/js/components/add-product.js
+++ b/src/static/js/components/add-product.js
@@ -60,7 +60,7 @@ const warrantyDescriptionTextAreaElement = document.getElementById("warranty-des
 
 // basic category  form fields
 const selectProductCategoryElement = document.getElementById("select-category");
-const addCategoryLabelElement = document.getElementById("add-category-label");
+const addCategoryLabelElement      = document.getElementById("add-category-label");
 const addCategoryInputFieldElement = document.getElementById("add-category");
 
 // pricing form fields

--- a/src/templates/account/product-management/add-new-product/detailed-description-specs.html
+++ b/src/templates/account/product-management/add-new-product/detailed-description-specs.html
@@ -22,8 +22,15 @@
                 <div class="color">
                 
                     <input type="checkbox" id="{{ color_dict.id }}" name="{{ color_dict.name }}" value="{{ color_dict.value }}"
-                        data-color="{{ color_dict.data_color }}">
-                
+                    data-color="{{ color_dict.data_color }}" 
+
+                      {% comment %} Loop through the list of colors choices and check any colors that the user has selected  {% endcomment %}
+                        {% for field in color%}
+                            {% if field == color_dict.value %}
+                                checked  
+                            {% endif %}
+                        {% endfor %}>  
+                  
                     <label for="{{ color_dict.value }}" class="{{ color_dict.value }}">{{ color_dict.value }}</label>
                     <br>
                 </div>
@@ -41,11 +48,25 @@
         <h4 class="text-capitalize">Size options</h4>
         <hr class="dividor">
 
+      
         <div class="sizes">
-
+          
             {% for size_dict in form.size_choices %}
+
                 <div class="{{ size_dict.class }} size">
-                    <input type="checkbox" id="{{ size_dict.id }}" name="{{ size_dict.name }}" value="{{ size_dict.value }}" data-size="{{ size_dict.data_size }}">
+                    
+                    
+                    <input type="checkbox" id="{{ size_dict.id }}" name="{{ size_dict.name }}" value="{{ size_dict.value }}"
+                      data-size="{{ size_dict.data_size }}" 
+                      
+                      {% comment %} Loop through the list of size choices and check any sizes that the user has selected {% endcomment %}
+                      {% for field in  size %}
+                            {% if field == size_dict.value %}
+                                checked  
+                            {% endif %}
+                      {% endfor %}
+                      >
+                       
                     <label for="{{ size_dict.value }}" class="{{ size_dict.class }}">{{ size_dict.value }}</label><br>
                 </div>
             {% endfor %}

--- a/src/templates/account/product-management/add-new-product/review-and-submit.html
+++ b/src/templates/account/product-management/add-new-product/review-and-submit.html
@@ -19,9 +19,9 @@
                     <h4 id="product-name-header">Product Name</h4>
                     <p class="product-name">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button aria-label="Edit Product Name" onclick="prevPage(event, 1)">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'basic_description_form' %}">
+                    <button aria-label="Edit Product Name">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="product-category-header">
@@ -29,9 +29,9 @@
                     <h4 id="product-category-header">Product Category</h4>
                     <p class="product-category">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button aria-label="Edit Product Category" onclick="prevPage(event, 1)">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'basic_description_form' %}">
+                    <button aria-label="Edit Product Name">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="new-category-header">
@@ -39,9 +39,9 @@
                     <h4 id="new-category-header">New Category added</h4>
                     <p class="brand">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button aria-label="Edit Brand" onclick="prevPage(event, 1)">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'basic_description_form' %}">
+                    <button aria-label="Edit Product Name">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="brand-header">
@@ -49,9 +49,9 @@
                     <h4 id="brand-header">Brand</h4>
                     <p class="brand">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button aria-label="Edit Brand" onclick="prevPage(event, 1)">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'basic_description_form' %}">
+                    <button aria-label="Edit Product Name">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="sku-header">
@@ -59,9 +59,9 @@
                     <h4 id="sku-header">SKU (Stock Keeping Unit)</h4>
                     <p class="stock-keeping">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button aria-label="Edit SKU" onclick="prevPage(event, 1)">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'basic_description_form' %}">
+                    <button aria-label="Edit Product Name">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="upc-header">
@@ -69,9 +69,9 @@
                     <h4 id="upc-header">UPC (Universal Product Code)</h4>
                     <p class="upc">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button aria-label="Edit UPC" onclick="prevPage(event, 1)">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'basic_description_form' %}">
+                    <button aria-label="Edit Product Name">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="short-description-header">
@@ -79,9 +79,9 @@
                     <h4 id="short-description-header">Short Description</h4>
                     <p class="short-description">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button aria-label="Edit Short Description" onclick="prevPage(event, 1)">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'basic_description_form' %}">
+                    <button aria-label="Edit Product Name">Edit</button>
+                </a>
             </div>
         </div>
 
@@ -97,9 +97,9 @@
                     <h4 id="color-options-header">Color Options</h4>
                     <p id="list-of-colors">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button aria-label="Edit Color Options" onclick="prevPage(event, 2)">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'detailed_description_form' %}">
+                    <button aria-label="Edit Color Options">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="product-length-header">
@@ -107,18 +107,18 @@
                     <h4 id="product-dimensions-header">Product length</h4>
                     <p id="length">Not entered/p>
                 </div>
-                <div class="edit">
-                    <button aria-label="Edit Product length" onclick="prevPage(event, 2)">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'detailed_description_form' %}">
+                    <button aria-label="Edit Color Options">Edit</button>
+                </a>
             </div>
             <div class="product-info space-between" role="group" aria-labelledby="product-width-header">
                 <div class="info">
                     <h4 id="product-width-header">Product Width</h4>
                     <p id="width">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button aria-label="Edit Product width" onclick="prevPage(event, 2)">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'detailed_description_form' %}">
+                    <button aria-label="Edit Color Options">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="product-height-header">
@@ -126,18 +126,18 @@
                     <h4 id="product-height-header">Product Height</h4>
                     <p id="height">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button aria-label="Edit Product height" onclick="prevPage(event, 2)">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'detailed_description_form' %}">
+                    <button aria-label="Edit Color Options">Edit</button>
+                </a>
             </div>
             <div class="product-info space-between" role="group" aria-labelledby="size-options-header">
                 <div class="info">
                     <h4 id="size-options-header">Size Options</h4>
                     <p id="list-of-sizes">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button aria-label="Edit Size Options" onclick="prevPage(event, 2)">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'detailed_description_form' %}">
+                    <button aria-label="Edit Color Options">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="weight-options-header">
@@ -145,9 +145,9 @@
                     <h4 id="weight-options-header">Weight (grams)</h4>
                     <p id="weight">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button aria-label="Edit Weight Options" onclick="prevPage(event, 2)">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'detailed_description_form' %}">
+                    <button aria-label="Edit Color Options">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="description-header">
@@ -155,9 +155,9 @@
                     <h4 id="description-header">Description</h4>
                     <p id="detailed-description">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button aria-label="Edit Description" onclick="prevPage(event, 2)">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'detailed_description_form' %}">
+                    <button aria-label="Edit Color Options">Edit</button>
+                </a>
             </div>
         </div>
 
@@ -172,9 +172,9 @@
                     <h4 id="price-heading">Price</h4>
                     <p id="price-info">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 3)" aria-label="Edit price">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'pricing_and_inventory_form' %}">
+                    <button aria-label="Edit Color Options">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="availability-heading">
@@ -182,9 +182,9 @@
                     <h4 id="availability-heading">Availability</h4>
                     <p id="availability-info">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 3)" aria-label="Edit availability">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'pricing_and_inventory_form' %}">
+                    <button aria-label="Edit Color Options">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="discount-heading">
@@ -192,9 +192,9 @@
                     <h4 id="discount-heading">Add Discount</h4>
                     <p id="discount-info">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 3)" aria-label="Edit discount">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'pricing_and_inventory_form' %}">
+                    <button aria-label="Edit Color Options">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="discount-price-heading">
@@ -202,9 +202,9 @@
                     <h4 id="discount-price-heading">Discount Price</h4>
                     <p id="discount-price-info">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 3)" aria-label="Edit discount price">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'pricing_and_inventory_form' %}">
+                    <button aria-label="Edit Color Options">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="quantity-in-stock-heading">
@@ -212,9 +212,9 @@
                     <h4 id="quantity-in-stock-heading">Quantity in Stock</h4>
                     <p id="quantity-in-stock-info">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 3)" aria-label="Edit quantity in stock">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'pricing_and_inventory_form' %}">
+                    <button aria-label="Edit Color Options">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="min-order-quantity-heading">
@@ -222,9 +222,9 @@
                     <h4 id="min-order-quantity-heading">Minimum Order Quantity</h4>
                     <p id="min-order-quantity-info">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 3)" aria-label="Edit minimum order quantity">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'pricing_and_inventory_form' %}">
+                    <button aria-label="Edit Color Options">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="max-order-quantity-heading">
@@ -232,9 +232,9 @@
                     <h4 id="max-order-quantity-heading">Maximum Order Quantity</h4>
                     <p id="max-order-quantity-info">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 3)" aria-label="Edit maximum order quantity">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'pricing_and_inventory_form' %}">
+                    <button aria-label="Edit Color Options">Edit</button>
+                </a>
             </div>
         </div>
 
@@ -247,23 +247,13 @@
 
             <div class="product-info space-between">
                 <h3 id="image-media-heading" class="product-section-header">Image and Media</h3>
-                <div class="edit">
-                    <button onclick="prevPage(event, 4)" aria-label="Edit image and media section">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'images_and_media_form' %}">
+                    <button aria-label="Edit Color Options">Edit</button>
+                </a>
             </div>
 
             <div class="product-info flex-col">
-                <p class="highlight padding-bottom-md padding-top-md">
-                    Warning: Due to security restrictions in web browsers, JavaScript cannot access
-                    or display local file paths directly. As a result, images cannot be shown in the review section because
-                    their local file paths are not accessible—only the file name is available, and so the file paths cannot
-                    be stored for later.
-                    Since the backend for image handling isn’t set up yet,
-                    selected images won’t be displayed until the backend is operational.
-                    However, you can still view the name of the image file you selected under the
-                    placeholder image.
-                </p>
-
+               
                 <div class="product-info img-preview" role="group" aria-labelledby="image-gallery-heading">
 
                     <div class="info primary-img review-product-img">
@@ -299,9 +289,9 @@
                     <h4 id="length-heading">Length</h4>
                     <p id="length-info">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 5)" aria-label="Edit length">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'shipping_and_delivery_form' %}">
+                    <button aria-label="Edit length">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="width-heading">
@@ -309,9 +299,9 @@
                     <h4 id="width-heading">Width</h4>
                     <p id="width-info">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 5)" aria-label="Edit width">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'shipping_and_delivery_form' %}">
+                    <button aria-label="Edit length">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="height-heading">
@@ -319,9 +309,9 @@
                     <h4 id="height-heading">Height</h4>
                     <p id="height-info">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 5)" aria-label="Edit height">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'shipping_and_delivery_form' %}">
+                    <button aria-label="Edit length">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="shipping-weight-heading">
@@ -329,9 +319,9 @@
                     <h4 id="shipping-weight-heading">Shipping Weight (kg)</h4>
                     <p id="shipping-weight-info">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 5)" aria-label="Edit shipping weight">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'shipping_and_delivery_form' %}">
+                    <button aria-label="Edit length">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="shipping-options-heading">
@@ -339,9 +329,9 @@
                     <h4 id="shipping-options-heading">Shipping Options</h4>
                     <p id="shipping-options-info">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 5)" aria-label="Edit shipping options">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'shipping_and_delivery_form' %}">
+                    <button aria-label="Edit length">Edit</button>
+                </a>
             </div>
         </div>
         <hr class="dividor">
@@ -355,9 +345,9 @@
                     <h4 id="meta-title-heading">Meta Title</h4>
                     <p id="meta-title-info">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 6)" aria-label="Edit meta title">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'seo_and_meta_form' %}">
+                    <button aria-label="Edit length">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="meta-keywords-heading">
@@ -365,9 +355,9 @@
                     <h4 id="meta-keywords-heading">Meta Keywords</h4>
                     <p id="meta-keywords-info">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 6)" aria-label="Edit meta keywords">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'seo_and_meta_form' %}">
+                    <button aria-label="Edit length">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="meta-description-heading">
@@ -377,9 +367,9 @@
                         Not entered
                     </p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 6)" aria-label="Edit meta description">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'seo_and_meta_form' %}">
+                    <button aria-label="Edit length">Edit</button>
+                </a>
             </div>
         </div>
 
@@ -394,9 +384,9 @@
                     <h4 id="manufacturer-title-heading">Manufacturer Title</h4>
                     <p id="manufacturer-title-info">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 7)" aria-label="Edit manufacturer title">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'add_information_form' %}">
+                    <button aria-label="Edit length">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="country-of-origin-heading">
@@ -404,9 +394,9 @@
                     <h4 id="country-of-origin-heading">Country of Origin</h4>
                     <p id="country-of-origin-info">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 7)" aria-label="Edit country of origin">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'add_information_form' %}">
+                    <button aria-label="Edit length">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="return-policy-heading">
@@ -414,9 +404,9 @@
                     <h4 id="return-policy-heading">Return Policy</h4>
                     <p id="return-policy-info">Not entered</p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 7)" aria-label="Edit return policy">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'add_information_form' %}">
+                    <button aria-label="Edit length">Edit</button>
+                </a>
             </div>
 
             <div class="product-info space-between" role="group" aria-labelledby="warranty-heading">
@@ -426,9 +416,9 @@
                         Not entered
                     </p>
                 </div>
-                <div class="edit">
-                    <button onclick="prevPage(event, 7)" aria-label="Edit warranty">Edit</button>
-                </div>
+                <a class="edit" href="{% url 'add_information_form' %}">
+                    <button aria-label="Edit length">Edit</button>
+                </a>
             </div>
         </div>
 

--- a/src/templates/account/product-management/add-new-product/review-and-submit.html
+++ b/src/templates/account/product-management/add-new-product/review-and-submit.html
@@ -17,7 +17,15 @@
             <div class="product-info space-between" role="group" aria-labelledby="product-name-header">
                 <div class="info">
                     <h4 id="product-name-header">Product Name</h4>
-                    <p class="product-name">Not entered</p>
+                    <p class="product-name">
+
+                        {% if basic_form_data.name %} 
+                            {{ basic_form_data.name | capfirst }}
+                        {% else %}
+                            You haven't entered a value 
+                        {% endif %}
+
+                    </p>
                 </div>
                 <a class="edit" href="{% url 'basic_description_form' %}">
                     <button aria-label="Edit Product Name">Edit</button>
@@ -27,7 +35,15 @@
             <div class="product-info space-between" role="group" aria-labelledby="product-category-header">
                 <div class="info">
                     <h4 id="product-category-header">Product Category</h4>
-                    <p class="product-category">Not entered</p>
+                    <p id="product-category">
+
+                        {% if basic_form_data.category == "New" %} 
+                            {{ basic_form_data.category | capfirst }}
+                         {% else %}
+                             Not applicable since a new category has been chosen
+                        {% endif %}
+                    </p>
+                  
                 </div>
                 <a class="edit" href="{% url 'basic_description_form' %}">
                     <button aria-label="Edit Product Name">Edit</button>
@@ -37,7 +53,14 @@
             <div class="product-info space-between" role="group" aria-labelledby="new-category-header">
                 <div class="info">
                     <h4 id="new-category-header">New Category added</h4>
-                    <p class="brand">Not entered</p>
+                    <p id="new-category">
+                        {% if basic_form_data.new_category != "N/A" %} 
+                            {{ basic_form_data.new_category | capfirst }}
+                        {% else %}
+                            Not applicable since the product category has already been selected
+                        {% endif %}
+                    </p>
+                   
                 </div>
                 <a class="edit" href="{% url 'basic_description_form' %}">
                     <button aria-label="Edit Product Name">Edit</button>
@@ -47,7 +70,14 @@
             <div class="product-info space-between" role="group" aria-labelledby="brand-header">
                 <div class="info">
                     <h4 id="brand-header">Brand</h4>
-                    <p class="brand">Not entered</p>
+                    <p id="product-brand">
+                        {% if basic_form_data.brand %} 
+                            {{ basic_form_data.brand | capfirst }}
+                        {% else %}
+                             You haven't entered a value 
+                        {% endif %}
+                    </p>
+                   
                 </div>
                 <a class="edit" href="{% url 'basic_description_form' %}">
                     <button aria-label="Edit Product Name">Edit</button>
@@ -57,7 +87,14 @@
             <div class="product-info space-between" role="group" aria-labelledby="sku-header">
                 <div class="info">
                     <h4 id="sku-header">SKU (Stock Keeping Unit)</h4>
-                    <p class="stock-keeping">Not entered</p>
+                    <p id="product-sku">
+                        {% if basic_form_data.sku %} 
+                            {{ basic_form_data.sku | capfirst }}
+                        {% else %}
+                            You haven't entered a value 
+                        {% endif %}
+                    </p>
+                   
                 </div>
                 <a class="edit" href="{% url 'basic_description_form' %}">
                     <button aria-label="Edit Product Name">Edit</button>
@@ -67,7 +104,14 @@
             <div class="product-info space-between" role="group" aria-labelledby="upc-header">
                 <div class="info">
                     <h4 id="upc-header">UPC (Universal Product Code)</h4>
-                    <p class="upc">Not entered</p>
+                    <p id="product-upc">
+                        {% if basic_form_data.upc  %} 
+                            {{ basic_form_data.upc | capfirst }}
+                        {% else %}
+                            You haven't entered a value 
+                        {% endif %}
+                    </p>
+                   
                 </div>
                 <a class="edit" href="{% url 'basic_description_form' %}">
                     <button aria-label="Edit Product Name">Edit</button>
@@ -77,7 +121,13 @@
             <div class="product-info space-between" role="group" aria-labelledby="short-description-header">
                 <div class="info">
                     <h4 id="short-description-header">Short Description</h4>
-                    <p class="short-description">Not entered</p>
+                    <p id="product-short-description">
+                        {% if basic_form_data.short_description  %} 
+                          <p>{{ basic_form_data.short_description | capfirst }}</p>
+                        {% else %}
+                            You haven't entered a value 
+                        {% endif %}
+                    </p>
                 </div>
                 <a class="edit" href="{% url 'basic_description_form' %}">
                     <button aria-label="Edit Product Name">Edit</button>
@@ -95,7 +145,13 @@
             <div class="product-info space-between" role="group" aria-labelledby="color-options-header">
                 <div class="info">
                     <h4 id="color-options-header">Color Options</h4>
-                    <p id="list-of-colors">Not entered</p>
+                    <p id="product-colors">
+                        {% if detailed_form_data.color  %} 
+                            {{ detailed_form_data.color|join:", " }}
+                        {% else %}
+                             You haven't entered a value 
+                        {% endif %}
+                    </p>
                 </div>
                 <a class="edit" href="{% url 'detailed_description_form' %}">
                     <button aria-label="Edit Color Options">Edit</button>
@@ -105,7 +161,14 @@
             <div class="product-info space-between" role="group" aria-labelledby="product-length-header">
                 <div class="info">
                     <h4 id="product-dimensions-header">Product length</h4>
-                    <p id="length">Not entered/p>
+                    <p id="product-length">
+                        {% if detailed_form_data.length  %} 
+                            {{ detailed_form_data.length  }} cm
+                        {% else %}
+                            You haven't entered a value 
+                        {% endif %}
+                    </p>
+                   
                 </div>
                 <a class="edit" href="{% url 'detailed_description_form' %}">
                     <button aria-label="Edit Color Options">Edit</button>
@@ -114,7 +177,11 @@
             <div class="product-info space-between" role="group" aria-labelledby="product-width-header">
                 <div class="info">
                     <h4 id="product-width-header">Product Width</h4>
-                    <p id="width">Not entered</p>
+                    {% if detailed_form_data.width  %} 
+                        {{ detailed_form_data.width  }} cm
+                    {% else %}
+                        You haven't entered a value 
+                    {% endif %}
                 </div>
                 <a class="edit" href="{% url 'detailed_description_form' %}">
                     <button aria-label="Edit Color Options">Edit</button>
@@ -124,7 +191,14 @@
             <div class="product-info space-between" role="group" aria-labelledby="product-height-header">
                 <div class="info">
                     <h4 id="product-height-header">Product Height</h4>
-                    <p id="height">Not entered</p>
+                    <p id="product-height">
+                        {% if detailed_form_data.height  %} 
+                            {{ detailed_form_data.height  }} cm
+                        {% else %}
+                            You haven't entered a value 
+                        {% endif %}
+                    </p>
+                    
                 </div>
                 <a class="edit" href="{% url 'detailed_description_form' %}">
                     <button aria-label="Edit Color Options">Edit</button>
@@ -133,7 +207,11 @@
             <div class="product-info space-between" role="group" aria-labelledby="size-options-header">
                 <div class="info">
                     <h4 id="size-options-header">Size Options</h4>
-                    <p id="list-of-sizes">Not entered</p>
+                    {% if detailed_form_data.size  %} 
+                        {{ detailed_form_data.size|join:", "  }}
+                    {% else %}
+                        You haven't entered a value 
+                    {% endif %}
                 </div>
                 <a class="edit" href="{% url 'detailed_description_form' %}">
                     <button aria-label="Edit Color Options">Edit</button>
@@ -142,8 +220,15 @@
 
             <div class="product-info space-between" role="group" aria-labelledby="weight-options-header">
                 <div class="info">
-                    <h4 id="weight-options-header">Weight (grams)</h4>
-                    <p id="weight">Not entered</p>
+                    <h4 id="weight-options-header">Weight</h4>
+                    <p id="product-weight">
+                        {% if detailed_form_data.weight  %} 
+                            {{ detailed_form_data.weight  }} Grams
+                        {% else %}
+                            You haven't entered a value 
+                        {% endif %}
+                    </p>
+                    
                 </div>
                 <a class="edit" href="{% url 'detailed_description_form' %}">
                     <button aria-label="Edit Color Options">Edit</button>
@@ -153,7 +238,15 @@
             <div class="product-info space-between" role="group" aria-labelledby="description-header">
                 <div class="info">
                     <h4 id="description-header">Description</h4>
-                    <p id="detailed-description">Not entered</p>
+                    <p id="product-detailed-description">
+                        {% if detailed_form_data.description  %} 
+                            <p id="detailed-description">{{ detailed_form_data.description  }}</p>
+                        {% else %}
+                            You haven't entered a value 
+                        {% endif %}
+                    </p>
+                    
+                    
                 </div>
                 <a class="edit" href="{% url 'detailed_description_form' %}">
                     <button aria-label="Edit Color Options">Edit</button>
@@ -170,7 +263,16 @@
             <div class="product-info space-between" role="group" aria-labelledby="price-heading">
                 <div class="info">
                     <h4 id="price-heading">Price</h4>
-                    <p id="price-info">Not entered</p>
+                    <p id="product-price">
+
+                        {% if price_and_inventory_data.price %}
+                           £{{ price_and_inventory_data.price }}
+                        {% else %}
+                           You haven't entered a value
+                        {% endif %}
+
+                    </p>
+                   
                 </div>
                 <a class="edit" href="{% url 'pricing_and_inventory_form' %}">
                     <button aria-label="Edit Color Options">Edit</button>
@@ -180,7 +282,23 @@
             <div class="product-info space-between" role="group" aria-labelledby="availability-heading">
                 <div class="info">
                     <h4 id="availability-heading">Availability</h4>
-                    <p id="availability-info">Not entered</p>
+                    <p id="product-availability">
+
+                        {% if price_and_inventory_data.category %}
+
+                            {% if price_and_inventory_data.category == 'is' %} 
+                                The item is in stock 
+                            {% elif  price_and_inventory_data.category == 'oos' %} 
+                                The item is out of stock 
+                            {% else %}
+                                The item has been pre-ordered
+                            {% endif %}
+                            
+                        {% else %}
+                            You haven't entered a value
+                        {% endif %}
+                    </p>
+                   
                 </div>
                 <a class="edit" href="{% url 'pricing_and_inventory_form' %}">
                     <button aria-label="Edit Color Options">Edit</button>
@@ -190,7 +308,14 @@
             <div class="product-info space-between" role="group" aria-labelledby="discount-heading">
                 <div class="info">
                     <h4 id="discount-heading">Add Discount</h4>
-                    <p id="discount-info">Not entered</p>
+                    <p id="product-choose-discount">
+                        {% if price_and_inventory_data.select_discount == "no" %}
+                            You have chosen not to add a discount to this item
+                        {% else %}
+                            You have chosen to add a discount to this item
+                        {% endif %}
+                    </p>
+                   
                 </div>
                 <a class="edit" href="{% url 'pricing_and_inventory_form' %}">
                     <button aria-label="Edit Color Options">Edit</button>
@@ -200,7 +325,14 @@
             <div class="product-info space-between" role="group" aria-labelledby="discount-price-heading">
                 <div class="info">
                     <h4 id="discount-price-heading">Discount Price</h4>
-                    <p id="discount-price-info">Not entered</p>
+                    <p id="product-add-a-discount">
+                        {% if price_and_inventory_data.add_discount == None %}
+                            Not applicable because you have chosen not to add a discount
+                        {% else %}
+                           £{{ price_and_inventory_data.add_discount }}
+                        {% endif %}
+                    </p>
+                  
                 </div>
                 <a class="edit" href="{% url 'pricing_and_inventory_form' %}">
                     <button aria-label="Edit Color Options">Edit</button>
@@ -210,7 +342,17 @@
             <div class="product-info space-between" role="group" aria-labelledby="quantity-in-stock-heading">
                 <div class="info">
                     <h4 id="quantity-in-stock-heading">Quantity in Stock</h4>
-                    <p id="quantity-in-stock-info">Not entered</p>
+
+                    <p id="product-stock-quantity">
+                        {% if price_and_inventory_data.quantity_stock  %}
+                            {{ price_and_inventory_data.quantity_stock }}
+                        {% elif price_and_inventory_data.quantity_stock == 0 %}
+                            You currently have no stock
+                        {% else %}
+                            You haven't entered a value
+                        {% endif %}
+                    </p>
+                   
                 </div>
                 <a class="edit" href="{% url 'pricing_and_inventory_form' %}">
                     <button aria-label="Edit Color Options">Edit</button>
@@ -220,7 +362,17 @@
             <div class="product-info space-between" role="group" aria-labelledby="min-order-quantity-heading">
                 <div class="info">
                     <h4 id="min-order-quantity-heading">Minimum Order Quantity</h4>
-                    <p id="min-order-quantity-info">Not entered</p>
+                    <p id="product-minimum-order">
+
+                        {% if price_and_inventory_data.minimum_order  %}
+                             {{ price_and_inventory_data.minimum_order }}
+                        {% elif price_and_inventory_data.minimum_order == 0 %}
+                            There is no minimum stock order
+                        {% else %}
+                            You haven't entered a value
+                        {% endif %}
+                    </p>
+                  
                 </div>
                 <a class="edit" href="{% url 'pricing_and_inventory_form' %}">
                     <button aria-label="Edit Color Options">Edit</button>
@@ -230,7 +382,17 @@
             <div class="product-info space-between" role="group" aria-labelledby="max-order-quantity-heading">
                 <div class="info">
                     <h4 id="max-order-quantity-heading">Maximum Order Quantity</h4>
-                    <p id="max-order-quantity-info">Not entered</p>
+                    <p id="product-maximum-order">
+
+                        {% if price_and_inventory_data.maximum_order  %}
+                            {{ price_and_inventory_data.maximum_order }}
+                        {% elif price_and_inventory_data.maximum_order == 0 %}
+                            There is no maximum stock order
+                        {% else %}
+                            You haven't entered a value
+                        {% endif %}
+                    </p>
+                   
                 </div>
                 <a class="edit" href="{% url 'pricing_and_inventory_form' %}">
                     <button aria-label="Edit Color Options">Edit</button>
@@ -256,23 +418,21 @@
                
                 <div class="product-info img-preview" role="group" aria-labelledby="image-gallery-heading">
 
-                    <div class="info primary-img review-product-img">
-                        <img src="{%  static '/img/display/jpg/placeholder.jpg' %}"
-                            alt="Placeholder image of the primary product" class="review-img">
-                        <p>Not entered</p>
-                    </div>
+                    {% for encoded_image in image_and_media_data %}
 
-                    <div class="info secondary-img review-product-img">
-                        <img src="{%  static '/img/display/jpg/placeholder.jpg' %}" alt="Placeholder image of a side view"
-                            class="review-img">
-                        <p>Not entered</p>
-                    </div>
+                        {% if encoded_image %}
+                            <div class="info image-and-media-images review-product-img">
+                               
+                                <img src="data:image/jpeg;base64,{{ encoded_image }}" alt="Image" class="review-img" alt="Image should be here">
+                            </div>
 
-                    <div class="info third-img review-product-img">
-                        <img src="{%  static '/img/display/jpg/placeholder.jpg' %}"
-                            alt="Placeholder image of another side view" class="review-img">
-                        <p>Not entered</p>
-                    </div>
+                        {% else %}
+                            <div class="info primary-img review-product-img">
+                                <p>The image was not found </p>
+                            </div>
+                        {% endif %}
+                    {% endfor %}
+
                 </div>
             </div>
         </div>
@@ -287,7 +447,16 @@
             <div class="product-info space-between" role="group" aria-labelledby="length-heading">
                 <div class="info">
                     <h4 id="length-heading">Length</h4>
-                    <p id="length-info">Not entered</p>
+
+                    <p id="product-shipping-length">
+
+                        {% if shipping_and_delivery_data.length %}
+                            {{ shipping_and_delivery_data.length }}
+                        {% else %}
+                            You haven't entered a value
+                        {% endif %}
+                    </p>
+                   
                 </div>
                 <a class="edit" href="{% url 'shipping_and_delivery_form' %}">
                     <button aria-label="Edit length">Edit</button>
@@ -297,7 +466,15 @@
             <div class="product-info space-between" role="group" aria-labelledby="width-heading">
                 <div class="info">
                     <h4 id="width-heading">Width</h4>
-                    <p id="width-info">Not entered</p>
+
+                    <p id="product-shipping-width">
+                        {% if shipping_and_delivery_data.width %}
+                            {{ shipping_and_delivery_data.width }}
+                        {% else %}
+                             You haven't entered a value
+                        {% endif %}
+                    </p>
+                   
                 </div>
                 <a class="edit" href="{% url 'shipping_and_delivery_form' %}">
                     <button aria-label="Edit length">Edit</button>
@@ -307,7 +484,15 @@
             <div class="product-info space-between" role="group" aria-labelledby="height-heading">
                 <div class="info">
                     <h4 id="height-heading">Height</h4>
-                    <p id="height-info">Not entered</p>
+                    <p id="product-shipping-height">
+
+                        {% if shipping_and_delivery_data.height %}
+                            {{ shipping_and_delivery_data.height }}
+                        {% else %}
+                            You haven't entered a value
+                        {% endif %}
+                    </p>
+                   
                 </div>
                 <a class="edit" href="{% url 'shipping_and_delivery_form' %}">
                     <button aria-label="Edit length">Edit</button>
@@ -317,7 +502,15 @@
             <div class="product-info space-between" role="group" aria-labelledby="shipping-weight-heading">
                 <div class="info">
                     <h4 id="shipping-weight-heading">Shipping Weight (kg)</h4>
-                    <p id="shipping-weight-info">Not entered</p>
+                    <p id="product-shipping-weight">
+
+                        {% if shipping_and_delivery_data.weight %}
+                             {{ shipping_and_delivery_data.weight }}
+                        {% else %}
+                            You haven't entered a value
+                        {% endif %}
+                    </p>
+                    
                 </div>
                 <a class="edit" href="{% url 'shipping_and_delivery_form' %}">
                     <button aria-label="Edit length">Edit</button>
@@ -327,7 +520,15 @@
             <div class="product-info space-between" role="group" aria-labelledby="shipping-options-heading">
                 <div class="info">
                     <h4 id="shipping-options-heading">Shipping Options</h4>
-                    <p id="shipping-options-info">Not entered</p>
+                    
+                    <p id="product-shipping-delivery-options">
+                        {% if shipping_and_delivery_data.shipping %}
+                            {{ shipping_and_delivery_data.shipping | join:", " }}
+                        {% else %}
+                            You haven't entered a value
+                        {% endif %}
+                    </p>
+                   
                 </div>
                 <a class="edit" href="{% url 'shipping_and_delivery_form' %}">
                     <button aria-label="Edit length">Edit</button>
@@ -343,7 +544,17 @@
             <div class="product-info space-between" role="group" aria-labelledby="meta-title-heading">
                 <div class="info">
                     <h4 id="meta-title-heading">Meta Title</h4>
-                    <p id="meta-title-info">Not entered</p>
+                    
+                    <p id="product-meta-titla">
+
+                        {% if seo_management_data.meta_title %}
+                            {{ seo_management_data.meta_title }}
+                        {% else %}
+                            You haven't entered a value
+                        {% endif %}
+                    </p>
+                    
+                  
                 </div>
                 <a class="edit" href="{% url 'seo_and_meta_form' %}">
                     <button aria-label="Edit length">Edit</button>
@@ -353,7 +564,17 @@
             <div class="product-info space-between" role="group" aria-labelledby="meta-keywords-heading">
                 <div class="info">
                     <h4 id="meta-keywords-heading">Meta Keywords</h4>
-                    <p id="meta-keywords-info">Not entered</p>
+
+                    <p id="product-meta-keywords">
+
+                        {% if seo_management_data.meta_keywords %}
+                            {{ seo_management_data.meta_keywords }}
+                        {% else %}
+                        
+                            You haven't entered a value
+                        {% endif %}
+                    </p>
+                   
                 </div>
                 <a class="edit" href="{% url 'seo_and_meta_form' %}">
                     <button aria-label="Edit length">Edit</button>
@@ -363,9 +584,16 @@
             <div class="product-info space-between" role="group" aria-labelledby="meta-description-heading">
                 <div class="info">
                     <h4 id="meta-description-heading">Meta Description</h4>
-                    <p id="meta-description-info">
-                        Not entered
+
+                    <p id="product-meta-description">
+
+                        {% if seo_management_data.meta_description %}
+                            {{ seo_management_data.meta_description  }}
+                        {% else %}
+                            You haven't entered a value
+                        {% endif %}
                     </p>
+                   
                 </div>
                 <a class="edit" href="{% url 'seo_and_meta_form' %}">
                     <button aria-label="Edit length">Edit</button>
@@ -382,7 +610,17 @@
             <div class="product-info space-between" role="group" aria-labelledby="manufacturer-title-heading">
                 <div class="info">
                     <h4 id="manufacturer-title-heading">Manufacturer Title</h4>
-                    <p id="manufacturer-title-info">Not entered</p>
+
+                    <p id="product-manufacter-title">
+
+                        {% if additional_information_data.title %}
+                            {{ additional_information_data.title  }}
+                        {% else %}
+                            You haven't entered a value
+                        {% endif %}
+                    </p>
+                   
+                   
                 </div>
                 <a class="edit" href="{% url 'add_information_form' %}">
                     <button aria-label="Edit length">Edit</button>
@@ -391,8 +629,17 @@
 
             <div class="product-info space-between" role="group" aria-labelledby="country-of-origin-heading">
                 <div class="info">
-                    <h4 id="country-of-origin-heading">Country of Origin</h4>
-                    <p id="country-of-origin-info">Not entered</p>
+                    <h4 id="country-of-origin-heading">Country of origin </h4>
+                    <p id="product-country-code">
+
+                        {% if additional_information_data.title %}
+                            Country code: {{ additional_information_data.countries  }}
+                        {% else %}
+                            You haven't entered a value
+                        {% endif %}
+                    </p>
+                    
+                   
                 </div>
                 <a class="edit" href="{% url 'add_information_form' %}">
                     <button aria-label="Edit length">Edit</button>
@@ -402,7 +649,20 @@
             <div class="product-info space-between" role="group" aria-labelledby="return-policy-heading">
                 <div class="info">
                     <h4 id="return-policy-heading">Return Policy</h4>
-                    <p id="return-policy-info">Not entered</p>
+                        <p id="product-return-policy-message">
+                            {% if additional_information_data.return_policy %}
+
+                                {% if additional_information_data.return_policy == "n" %}
+                                    This item is not eligible for return.
+                                {% else %}
+                                    This item is eligible for return.
+                                {% endif %}
+                        
+                            {% else %}
+                                You haven't entered a value
+                            {% endif %}
+                        </p>
+                       
                 </div>
                 <a class="edit" href="{% url 'add_information_form' %}">
                     <button aria-label="Edit length">Edit</button>
@@ -412,8 +672,13 @@
             <div class="product-info space-between" role="group" aria-labelledby="warranty-heading">
                 <div class="info">
                     <h4 id="warranty-heading">Warranty</h4>
-                    <p id="warranty-info">
-                        Not entered
+                    <p id="produuct-warranty-info">
+                       
+                        {% if additional_information_data.description %}
+                            {{ additional_information_data.description }} 
+                        {% else %}
+                            You haven't entered a value</p>
+                        {% endif %}
                     </p>
                 </div>
                 <a class="edit" href="{% url 'add_information_form' %}">

--- a/src/templates/account/product-management/add-new-product/shipping-and-delivery.html
+++ b/src/templates/account/product-management/add-new-product/shipping-and-delivery.html
@@ -50,13 +50,21 @@
                 <h4 class="sr-only">Select a shipping method</h4>
 
                 {% for delivery_option_dict in form.delivery_options %}
-
+                    
                     <label>
                        
                         <input type="checkbox" name="{{ delivery_option_dict.input.name }}" value="{{ delivery_option_dict.input.value }}" 
-                           data-shipping-type="{{ delivery_option_dict.data.shipping_type }}" data-cost="{{ delivery_option_dict.data.cost }}"
-                            data-delivery-time="{{ delivery_option_dict.data.delivery_data }}" aria-describedby="{{ delivery_option.aria.describedby }}"
-                            id="{{ delivery_option_dict.id }}">
+                            aria-describedby="{{ delivery_option.aria.describedby }}"
+                            id="{{ delivery_option_dict.id }}" 
+                            
+                            {% comment %} Loop through the list of dictionary choices and check any dictionary that the user has selected  {% endcomment %}
+                            {% for field in shipping %}
+                               
+                                {% if field == delivery_option_dict.input.value %}
+                                    checked  
+                                {% endif %}
+                            {% endfor %}
+                            >
                      
                         {{ delivery_option_dict.label }}
                     </label><br>


### PR DESCRIPTION

**Feat: Complete `review-and-submit.html` page**

- Finished the `review-and-submit.html` page, allowing users to see a full summary of their product, including pictures added, 
   after entering details on the add product page.

- Added the ability for checkboxes on the `detailed-description-specs.html` and `shipping-and-delivery.html` pages to retain their values 
   even after refresh or navigation. Previously, these checkboxes would reset upon page refresh or when navigating away and back.

- **Note:**

  - The `submit` button on the `review-and-submit.html` page is currently inactive because the necessary backend code has not yet been implemented.
  - Data persistence is maintained across page refreshes, including any checkbox selections. However, there is an issue with the images on the `images-and-media.html` page. When an image is uploaded, it is stored in the session, but its reference is not persistent in the form fields.

    - **Details:**
      - After uploading an image and clicking `Next`, if you return to the `images-and-media.html` page, the image title will not appear in the 
      form fields. Despite this, the image data remains in the session, meaning you can still see the previously entered data on
       the `review-and-submit.html` page. However, to navigate back to the `review-and-submit.html` page, you must use the URL directly. 
       If you attempt to go to the review page by clicking `Next`, the form will prompt you to upload an image again. 
       This occurs because the image data, although present in the session, is not recognized as a persistent file object.

    - **Clarifications on the reason why this happens:**

      - **Storing Images in Sessions:** The Images are complex objects and as a result cannot be directly stored in a session 
      (which is typically used for serialized data like strings, integers, etc.). Instead, what is stored are image file paths 
      or references to temporary storage locations.
      - **Losing Image State on Refresh:** Since the form fields do not recognize a stored path or URL string as a file object,
       the image does not reappear in the form field when you navigate back to the `images-and-media.html` page. 
       This is why the form fields appear empty even though the image data is still stored in the session.
      - **Navigating via URL:** You can still see the uploaded image data on the `review-and-submit.html` page by 
      navigating directly to the URL. However, the form handling mechanism does not automatically reload the file inputs, 
      so the form expects new uploads if you try to navigate using the standard flow.

    - **Cause of the Issue:** The problem arises because images cannot be stored directly in a request session—they are memory objects,
      not simple data types. To persist images thus allowing the user to see their images, they need to be stored in a temporary folder
       with a reference to their location. 
      However, this results in the image being stored as a URL string rather than a file memory object. As a consequent of this, 
      the form doesn't recognize it as a valid file input, leading to the observed persistence issue.

**Todo:**
- Implement the model to store the product data when the user submits the form.
- Activate the submit button on the review page once the backend functionality is complete.
