### PR TITLE
Fix form error when banning users and remove redundant `ban_reason` field

### DIFF
--- a/src/authentication/forms/ban_user_form.py
+++ b/src/authentication/forms/ban_user_form.py
@@ -40,7 +40,6 @@ class BanUserAdminForm(forms.ModelForm):
      
         user_ban_record = super().save(commit=False)
 
-        ban_reason      = self.cleaned_data["ban_reason"]
         ban_start_date  = self.cleaned_data.get("ban_start_date", None)
         ban_expires_on  = self.cleaned_data.get("ban_expires_on", None)
         

--- a/src/authentication/forms/ban_user_form.py
+++ b/src/authentication/forms/ban_user_form.py
@@ -16,9 +16,13 @@ class BanUserAdminForm(forms.ModelForm):
         ban_start_date = cleaned_data.get("ban_start_date", None)
         ban_expires_on = cleaned_data.get("ban_expires_on", None)
         
+        is_banned_msg  = ""
+        
          # Check if the user is already banned
         user_ban_record = BanUser.objects.filter(user=cleaned_data["user"]).first()
-        is_banned_msg = user_ban_record.is_user_already_banned()
+        
+        if user_ban_record:
+            is_banned_msg = user_ban_record.is_user_already_banned()
         
         if is_banned_msg:
             raise forms.ValidationError(is_banned_msg)
@@ -43,7 +47,7 @@ class BanUserAdminForm(forms.ModelForm):
         if ban_start_date and ban_expires_on:
 
             num_of_days_to_ban = calculate_days_between_dates(ban_expires_on, ban_start_date)
-            user_ban_record.ban_for_x_amount_of_days(ban_reason, num_of_days_to_ban, save=False)
+            user_ban_record.ban_for_x_amount_of_days(num_of_days_to_ban, save=False)
       
           
         if commit:

--- a/src/authentication/tests/test_ban_user_model.py
+++ b/src/authentication/tests/test_ban_user_model.py
@@ -229,8 +229,8 @@ class CustomBanUserModelTestCase(TestCase):
         user = User.get_by_email(email=self.temporarily_banned_user.user.email)
         
         self.assertIsNotNone(user)
-        self.assertFalse(user.is_banned)     # Ensure the user is flagged as temporarily banned
-        self.assertTrue(user.is_temp_ban)
+        self.assertFalse(user.is_banned)     
+        self.assertTrue(user.is_temp_ban) # Ensure the user is flagged as temporarily banned
         
         user_ban_record = BanUser.objects.filter(user=user).first()
         


### PR DESCRIPTION
- Error 1: Resolved issue where attempting to check `is_user_already_banned()` on a non-existent `user_ban_record`
   caused a `NoneType` error. Now, if the user doesn't exist, the check handles it safely without raising an exception.

- Error 2: Removed the `ban_reason` parameter from the `ban_for_x_amount_of_days(num_of_days_to_ban, save=False)` method, 
  because it can now initialised during the creation of the `BanModel`. This slight adjustment now aligns with recent refactoring 
  of the `BanModel`.
