### PR TITLE
Add tests for password validation for NewPasswordForm and ForgottenPasswordForm

### DIFF
--- a/src/authentication/tests/test_forgotten_email_form.py
+++ b/src/authentication/tests/test_forgotten_email_form.py
@@ -1,0 +1,76 @@
+from django.test import TestCase
+
+from authentication.forms.passwords.forgotten_password import ForgottenPasswordForm
+
+
+class ForgottenPasswordFormTest(TestCase):
+    
+    def setUp(self) -> None:
+        
+        self.form_data = {
+            "email": "test_email@example.com"
+        }
+        
+    def test_forgotten_password_form_valid_data(self):
+        """Test forgotten password form when form data is valid"""
+        
+        form = ForgottenPasswordForm(data=self.form_data)
+        self.assertTrue(form.is_valid())
+    
+    def test_empty_forgotten_password_form(self):
+        """Test forgotten password form when form data is valid"""
+        form_data = {
+            
+        }
+        form = ForgottenPasswordForm(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('email', form.errors)
+    
+    def test_invalid_email(self):
+        """Test forgotten password form when form the email is invalid"""
+        
+        form_data = {
+            "email": "invalid_email"
+        }
+        form = ForgottenPasswordForm(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('email', form.errors)
+        self.assertEqual(
+            form.errors['email'],
+            ['Enter a valid email address.']
+        )
+    
+    def test_forgotten_password_form_valid_data(self):
+        """Test if it exceeds the maximum length"""
+        MAXIMUM_LENGTH = 60
+        email          = "e" * MAXIMUM_LENGTH + "@gmail.com"
+        
+        form_data = {
+            "email": email,
+        }
+        
+        form = ForgottenPasswordForm(data=form_data)
+        self.assertFalse(form.is_valid())
+        
+        self.assertEqual(
+            form.errors['email'],
+            ['Ensure this value has at most 60 characters (it has 70).']
+        )
+    
+    def test_email_with_leading_trailing_spaces(self): 
+        """test the email when it has trailing spaces"""
+        
+        form_data = {
+        "email": "   test_email@example.com   "
+        }
+        form = ForgottenPasswordForm(data=form_data)
+        self.assertTrue(form.is_valid())
+    
+    def test_email_case_insensitivity(self):
+        """test email that case insensitive"""
+        
+        form_data = {
+            "email": "TEST_EMAIL@EXAMPLE.COM"
+        }
+        form = ForgottenPasswordForm(data=form_data)
+        self.assertTrue(form.is_valid())

--- a/src/authentication/tests/test_new_password_form.py
+++ b/src/authentication/tests/test_new_password_form.py
@@ -1,0 +1,158 @@
+from django.test import TestCase
+from django import forms
+
+from authentication.forms.passwords.new_password import NewPasswordForm
+
+
+class NewPasswordFormTest(TestCase):
+    
+    def setUp(self):
+        self.form_data = {
+            "new_password": "Pa$$word1",
+            "confirm_password": "Pa$$word1",
+        }
+        
+    def test_new_password_form_valid_data(self):
+    
+        form = NewPasswordForm(data=self.form_data)
+        self.assertTrue(form.is_valid())
+
+    def test_new_password_form_empty_data(self):
+        
+        invalid_data = {
+            "new_password": "",
+            "confirm_password": ""
+        }
+        
+        form = NewPasswordForm(data=invalid_data)
+        self.assertFalse(form.is_valid())
+    
+    def test_new_password_form_when_new_password_is_empty(self):
+        invalid_data = {
+            "new_password": "",
+            "confirm_password": "Pa$$word1"
+        }
+        
+        form = NewPasswordForm(data=invalid_data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors["new_password"], ['This field is required.'])
+
+    def test_new_password_form_when_confirm_password_is_empty(self):
+        invalid_data = {
+            "new_password": "Pa$$word1",
+            "confirm_password": ""
+        }
+        
+        form = NewPasswordForm(data=invalid_data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors["confirm_password"], ['This field is required.'])
+        
+    def test_clean_new_password_raises_validation_error_with_incorrect_length(self):
+        
+        form_data = {
+            "new_password": "P", # to short
+            "confirm_password": "Pa$$word1"
+        }
+        
+        form = NewPasswordForm(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('new_password', form.errors)
+        
+        self.assertEqual(form.errors["new_password"], ["The password must contain at least eight characters"])
+        
+    
+    def test_new_password_raises_validation_error_with_incorrect_length(self):
+        
+        form_data = {
+            "new_password": "P", # to short
+            "confirm_password": "Pa$$word1"
+        }
+        
+        form = NewPasswordForm(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('new_password', form.errors)
+        
+        self.assertEqual(form.errors["new_password"], ["The password must contain at least eight characters"])
+    
+    def test_new_password_raises_validation_error_with_missing_numbers(self):
+        
+        form_data = {
+            "new_password": "Password", # missing numbers
+            "confirm_password": "Pa$$word1"
+        }
+        
+        form = NewPasswordForm(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('new_password', form.errors)
+        
+        self.assertEqual(form.errors["new_password"], ["The password must contain at least one number"])
+    
+    def test_new_password_raises_validation_error_with_no_lowercases(self):
+        
+        form_data = {
+            "new_password": "PA2SSWORD", # no lowercases
+            "confirm_password": "Pa$$word1"
+        }
+        
+        form = NewPasswordForm(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('new_password', form.errors)
+        
+        self.assertEqual(form.errors["new_password"], ["The password must contain at least one lowercase"])
+    
+    def test_new_password_raises_validation_error_with_no_lowercases(self):
+        
+        form_data = {
+            "new_password": "pass2word", # no uppercases
+            "confirm_password": "Pa$$word1"
+        }
+        
+        form = NewPasswordForm(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('new_password', form.errors)
+        
+        self.assertEqual(form.errors["new_password"], ["The password must contain at least one uppercase"])
+        
+    
+    def test_new_password_raises_validation_error_with_no_uppercases(self):
+        
+        form_data = {
+            "new_password": "pass2word", # no uppercases
+            "confirm_password": "Pa$$word1"
+        }
+        
+        form = NewPasswordForm(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('new_password', form.errors)
+        
+        self.assertEqual(form.errors["new_password"], ["The password must contain at least one uppercase"])
+    
+    
+    def test_new_password_raises_validation_error_with_no_special_characters(self):
+        
+        form_data = {
+            "new_password": "pass2Word", # no special characters
+            "confirm_password": "Pa$$word1"
+        }
+        
+        form = NewPasswordForm(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('new_password', form.errors)
+        
+        self.assertEqual(form.errors["new_password"], ["The password must contain at least one special character"])
+        
+    
+    def test_mismatch_password(self):
+        
+        form_data = {
+            "new_password": "Pa$$word1", 
+            "confirm_password": "Pa$$word2"
+        }
+        
+        form = NewPasswordForm(data=form_data)
+        self.assertFalse(form.is_valid())
+        
+          # Check if the 'non_field_errors' has the expected error
+        self.assertIn("The passwords does not match", form.non_field_errors())
+        
+       

--- a/src/authentication/tests/test_register_form.py
+++ b/src/authentication/tests/test_register_form.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from ..forms.register_form import RegisterForm
+from authentication.forms.register_form import RegisterForm
 
 
 class RegisterFormTest(TestCase):

--- a/src/templates/passwords/forgotten_password.html
+++ b/src/templates/passwords/forgotten_password.html
@@ -1,10 +1,7 @@
 {% extends "base.html" %}
-{% load static %}
 {% block title %}Forgotten Password{% endblock  %}
 
 {% block body %}
-
-   
 
     <div class="forgotten-password-container">
 
@@ -25,13 +22,5 @@
 
     </div>
     
-   
-
-
-
 {% endblock  %}
 
-
-{% block script  %}
-    <script type="module" src="{% static 'js/pages/auth.js' %}"></script>
-{% endblock  %}


### PR DESCRIPTION
- created `test_forgotten_email_form.py` and `test_new_password_form.py` files inside authentication/tests
- Implemented a series of tests including edge test cases for both NewPasswordForm and ForgottenPasswordForm.