### PR TITLE
Feat: Display latest subscription history first

### DIFF
--- a/src/static/js/pages/subscription.js
+++ b/src/static/js/pages/subscription.js
@@ -17,8 +17,7 @@ const csrfTokenField           = document.querySelector("input[name='csrfTokenMi
     validateElement(element, "The html is not a valid element", true);
 });
 
-const CSRF_TOKEN = csrfTokenField.value;
-
+const CSRF_TOKEN   = csrfTokenField.value;
 
 document.addEventListener("DOMContentLoaded", setUp);
 
@@ -112,6 +111,7 @@ function toggleTabVisibility(showTab, hideTabs, header) {
 };
 
 
+
 async function handleFormSubmit(event) {
 
     event.preventDefault();
@@ -131,6 +131,7 @@ async function handleFormSubmit(event) {
 
     const success = await handleResponse(response);
     if (success) {
+       PAGE_REFRESH = true;
        console.log("Successful");
     };
 

--- a/src/subscription/models.py
+++ b/src/subscription/models.py
@@ -162,8 +162,8 @@ class NewsletterSubscriptionHistory(models.Model):
     reason_for_unsubscribing = models.CharField(max_length=255, blank=True, null=True)
 
     class Meta:
-        verbose_name         = "Newsletter Subscription History"
-        verbose_name_plural  = "Newsletter Subscription Histories"
+        verbose_name         = "Subscription History"
+        verbose_name_plural  = "Subscription Histories"
         
     def __str__(self) -> str:
         return f"{self.email} - {self.action} on {self.timestamp}"
@@ -172,12 +172,12 @@ class NewsletterSubscriptionHistory(models.Model):
 class UnsubscribedNewsletterSubscription(NewsletterSubscription):
     class Meta:
         proxy              = True
-        verbose_name        = "Unsubscribed Newsletter Subscription"
-        verbose_name_plural = "Unsubscribed Newsletter Subscriptions"
+        verbose_name        = "Unsubscribed Subscription"
+        verbose_name_plural = "Unsubscribed Subscriptions"
 
 
 class SubscribedNewsletterSubscription(NewsletterSubscription):
     class Meta:
         proxy               = True
-        verbose_name        = "Subscribed Newsletter Subscription"
-        verbose_name_plural = "Subscribed Newsletter Subscriptions"
+        verbose_name        = "Subscribed Subscription"
+        verbose_name_plural = "Subscribed Subscriptions"

--- a/src/subscription/views.py
+++ b/src/subscription/views.py
@@ -78,8 +78,8 @@ def manage_subscription(request):
     
     subscription         = NewsletterSubscription.objects.filter(user=request.user).first()
     RESULT_PER_PAGE      = 25
-    history              = subscription.user.subscription_history.all()
-    subscription_history = history or []
+    latest_history       = subscription.user.subscription_history.order_by("-timestamp").all()
+    subscription_history = latest_history or []
     paginator            = Paginator(subscription_history, RESULT_PER_PAGE) 
     page_number          = request.GET.get("page", 1)
     page_obj             = paginator.get_page(page_number)

--- a/src/templates/account/subscription/manage_newsletter_subscription.html
+++ b/src/templates/account/subscription/manage_newsletter_subscription.html
@@ -72,41 +72,45 @@
 
         <table id="subscription-table" class="padding-top-md">
 
-            <thead>
-                <tr>
-                    <th>Subscription activity</th>
-                    <th>Start date</th>
-                    <th>End date</th>
-                    <th>Frequency</th>
-                    <th>Status</th>
-                    <th>Action</th>
-                 
-                </tr>
-            </thead>
+            {% if page_obj and page_obj.object_list %}
+                <thead>
+                    <tr>
+                        <th>Subscription activity</th>
+                        <th>Start date</th>
+                        <th>End date</th>
+                        <th>Frequency</th>
+                        <th>Status</th>
+                        <th>Action</th>
+                    
+                    </tr>
+                </thead>
 
-            {% for subscription in page_obj %}
-                <tr>
-                    <td>{{ subscription.title | title }}</td>
-                    <td>{{ subscription.timestamp }}</td>
+                {% for subscription in page_obj %}
+                    <tr>
+                        <td>{{ subscription.title | title }}</td>
+                        <td>{{ subscription.timestamp }}</td>
 
-                    {% if not subscription.unsubscribed_on %}
-                        <td>Ongoing</td>
-                    {% else %}
-                        {{ subscription.unsubscribed_on }}
-                    {% endif %}
-                    <td>{{ subscription.frequency | format_frequency }}</td>
+                        {% if not subscription.unsubscribed_on %}
+                            <td>Ongoing</td>
+                        {% else %}
+                            {{ subscription.unsubscribed_on }}
+                        {% endif %}
+                        <td>{{ subscription.frequency | format_frequency }}</td>
 
-                    {% if subscription.action == 'subscribed' %}
-                        <td>Active</td>
-                     {% else %}
-                        <td>Not Active</td>
-                     {% endif %}
-                    <td>
-                       {{ subscription.action | title }}
-                    </td>
-                </tr>
-            {% endfor %}
-           
+                        {% if subscription.action == 'subscribed' %}
+                            <td>Active</td>
+                        {% else %}
+                            <td>Not Active</td>
+                        {% endif %}
+                        <td>
+                        {{ subscription.action | title }}
+                        </td>
+                    </tr>
+                {% endfor %}
+            {% else %}
+                <p> Nothing to see </p>
+            {% endif %}
+            
             
             
         </table>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -2124,6 +2124,8 @@
 {% block script %}
     <script src="{% static 'js/modules/auth.js' %}" type="module"></script>
     <script src="{% static 'js/pages/main.js' %}" type="module"></script>
+    
+    <script src="{% static '/js/modules/delete-review.js' %}" type="module"></script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11.12.2/dist/sweetalert2.all.min.js"></script>
 {% endblock %}
 


### PR DESCRIPTION
- Implemented a feature to display the latest subscription history entries first.
- Added a conditional check to show a message when no subscription history is available.
- Included a script `<script src="{% static 'js/modules/delete-review.js' %}" type="module"></script>` in `index.html`
 to render the rating stars correctly within the testimonial section of the html page.

Known Issue:
- When the user updates the frequency in the UI via navigation tab, and navigates to the subscription history,
the latest data is not displayed immediately. A page refresh is required to view the latest entries.
This issue will be addressed in the next update.