### PR TITLE
Subscription table  merge rows

### DIFF
--- a/src/static/css/css.css
+++ b/src/static/css/css.css
@@ -3740,7 +3740,7 @@ legend {
     right: 0;
     border: 3px solid lavender;
     padding: 20px;
-    border-radius: 10%;
+    border-radius: 2%;
     background: white;
     text-transform: capitalize;
     cursor: pointer;

--- a/src/static/js/pages/subscription.js
+++ b/src/static/js/pages/subscription.js
@@ -20,10 +20,10 @@ const unsubscribeBtn           = document.getElementById("unsubscribe-btn");
 const cancelBtn                = document.querySelector(".cancel-btn");
 const spinner                  = document.querySelector(".spinner");
 const subscriptionTable        = document.getElementById("subscription-table");
-const mergeRows                = document.getElementById("merge_fields");
+const mergeRowsButton                = document.getElementById("merge_fields");
 
 const  addedRowIds = new Set();
-
+// console.log(addedRowIds);
 
 // check if the global elements are valid before proceeding
 [subscriptionTabContainer, 
@@ -35,7 +35,7 @@ const  addedRowIds = new Set();
     cancelBtn,
     feedbackForm,
     subscriptionTable,
-    mergeRows,
+    mergeRowsButton,
     csrfTokenField].forEach((element) => {
     validateElement(element, "The html is not a valid element");
 });
@@ -45,7 +45,7 @@ const CSRF_TOKEN   = csrfTokenField?.value;
 
 document.addEventListener("DOMContentLoaded", setUp);
 document.addEventListener(feedbackForm, handleFeedbackForm);
-mergeRows.addEventListener("click", handleMergeHighlightedRowsClick);
+mergeRowsButton.addEventListener("click", handleMergeHighlightedRowsClick);
 unsubscribeBtn?.addEventListener("click", handleUnsubscribeBtnClick);
 cancelBtn?.addEventListener("click", handleCancelButtonClick);
 
@@ -225,60 +225,55 @@ function toggleFeedBackContainer(show=true) {
 
 
 
-
 /**
- * Merges highlighted rows in the subscription table.
- * When the "Merge highlighted table rows" button is clicked, this function 
- * keeps only rows with the specified highlight class and hides all others.
- * 
- * @param {Event} e - The event triggered by the merge button click.
+ * Handles the merge row click for the table. When the user 
+ * highlights the rows of a given table and clicks the Merge highlighted table rows
+ * only the highlighted rows are shown an the rest are excluded
+ * @param {*} e 
  */
 function handleMergeHighlightedRowsClick(e) {
   
     const BACKGROUND_COLOR_CLASS = "yellow-bg";
 
-    const subscriptionCopyTable  = subscriptionTable.cloneNode(true);
-    const tbody                  = subscriptionTable.querySelector("tbody");
     const fragment               = document.createDocumentFragment();
+    const tbody                  = subscriptionTable.querySelector("tbody");
     let   highlightedRowFound    = false;
     
-    for (let row of subscriptionCopyTable.rows) {
+    for (let row of subscriptionTable.rows) {
 
-            if (row.classList.contains(BACKGROUND_COLOR_CLASS)) {
+        if (row.classList.contains(BACKGROUND_COLOR_CLASS)) {
+            if (!highlightedRowFound) {
                 highlightedRowFound = true;
-                
-                if (highlightedRowFound) {
-
-                    const rowId = row.getAttribute('data-id'); 
-
-                    if (!addedRowIds.has(rowId)) {
-                        fragment.appendChild(row);
-                        addedRowIds.add(rowId);
-                    }
-                                     
-                };
+            }
+        
+         
+            const rowCopy = row.cloneNode(true);
+            fragment.appendChild(rowCopy);
+            
+               
               
-            } ; 
+            }; 
     }
-
 
     if (highlightedRowFound) {
         clearTableBody(tbody);
-        subscriptionTable.appendChild(fragment);     
+        subscriptionTable.appendChild(fragment);
+        hideMergeButton();
         
-    };
+        
+    }
 }
 
 
 
-/**
- * Clears all rows from a given table's tbody element.
- * 
- * @param {HTMLElement} tbody - The HTML table body to clear.
- */
-function clearTableBody(tbody) {
-    validateElement(tbody, "The provided element is not a valid HTML element", true);
-    tbody.innerHTML = "";
+function clearTableBody(table) {
+    validateElement(table, "The html is not a valid HTML element", true);
+    table.innerHTML = "";
+};
+
+
+function hideMergeButton() {
+    mergeRowsButton.style.display = "none";
 }
 
 

--- a/src/static/js/pages/subscription.js
+++ b/src/static/js/pages/subscription.js
@@ -22,8 +22,6 @@ const spinner                  = document.querySelector(".spinner");
 const subscriptionTable        = document.getElementById("subscription-table");
 const mergeRowsButton                = document.getElementById("merge_fields");
 
-const  addedRowIds = new Set();
-// console.log(addedRowIds);
 
 // check if the global elements are valid before proceeding
 [subscriptionTabContainer, 
@@ -245,13 +243,8 @@ function handleMergeHighlightedRowsClick(e) {
             if (!highlightedRowFound) {
                 highlightedRowFound = true;
             }
-        
-         
             const rowCopy = row.cloneNode(true);
             fragment.appendChild(rowCopy);
-            
-               
-              
             }; 
     }
 


### PR DESCRIPTION
Fixed functionality allowing users to merge highlighted rows in the subscription table by selecting multiple rows 
and clicking the 'Merge highlighted table rows' button.

**Problem**: Previously, not all highlighted rows displayed upon merging due to an oversight in the cloning process, 
resulting in partial merges. This meant that you can highlight several rows and hit the merge button but only
a few will be merged. For example, if you highlighted six rows before clicking the merge button then only three will
be displayed.

**Solution**: Moved the `cloneNode` operation inside the `if` block to ensure only highlighted rows 
 are cloned and appended into the fragment. Also, removed the storage used to track row IDs, as the 'Merge' 
 button now disappears post-merge, this preventing duplicate merges until page refresh.

**Usage**: 
1. Log in and navigate to the subscriptions page.
2. Select the 'Subscription history' tab, highlight the desired rows, and click 'Merge highlighted table rows' 
to view only those selected.
